### PR TITLE
icon needs to be albumArtURI for Kodi

### DIFF
--- a/src/main/java/com/cajor/dk/dlna/ContentDirectoryBrowseTaskFragment.java
+++ b/src/main/java/com/cajor/dk/dlna/ContentDirectoryBrowseTaskFragment.java
@@ -329,8 +329,8 @@ public class ContentDirectoryBrowseTaskFragment extends Fragment {
 
             ItemModel itemModel = new ItemModel(getResources(),
                     R.drawable.ic_folder, service, item);
-
-            URI usableIcon = item.getFirstPropertyValue(DIDLObject.Property.UPNP.ICON.class);
+            
+            URI usableIcon = item.getFirstPropertyValue(DIDLObject.Property.UPNP.ALBUM_ART_URI.class);
             if (usableIcon != null)
                 itemModel.setIconUrl(usableIcon.toString());
 

--- a/src/main/java/com/cajor/dk/dlna/ContentDirectoryBrowseTaskFragment.java
+++ b/src/main/java/com/cajor/dk/dlna/ContentDirectoryBrowseTaskFragment.java
@@ -329,8 +329,11 @@ public class ContentDirectoryBrowseTaskFragment extends Fragment {
 
             ItemModel itemModel = new ItemModel(getResources(),
                     R.drawable.ic_folder, service, item);
-            
-            URI usableIcon = item.getFirstPropertyValue(DIDLObject.Property.UPNP.ALBUM_ART_URI.class);
+
+            URI usableIcon = item.getFirstPropertyValue(DIDLObject.Property.UPNP.ICON.class);
+            if (usableIcon == null || usableIcon.toString().isEmpty()) {
+                usableIcon = item.getFirstPropertyValue(DIDLObject.Property.UPNP.ALBUM_ART_URI.class);
+            }
             if (usableIcon != null)
                 itemModel.setIconUrl(usableIcon.toString());
 


### PR DESCRIPTION
Hi. If you change the icon to albumArtURI the icons show up in Kodi for Movies and TV Shows. I don't know if this breaks things for other upnp sources. Perhaps it needs to be used if the icon is empty.